### PR TITLE
docs: correct syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ async _getContent() {
 
 the return value will be like this:
 
-```json
+```javascript
 {
   text: "clipboard text",
   changeCount: 100,


### PR DESCRIPTION
I think here should be JS rather than JSON (especially without quotes).