### PR TITLE
fix: implement requiresMainQueueSetup for RNAdvancedClipboard

### DIFF
--- a/ios/RNAdvancedClipboard.m
+++ b/ios/RNAdvancedClipboard.m
@@ -25,6 +25,11 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(setString:(NSString *)content)
 {
     UIPasteboard *clipboard = [UIPasteboard generalPasteboard];


### PR DESCRIPTION
This PR removes the yellow-box warning about requiresMainQueueSetup implementation