### PR TITLE
chore: update compileSdkVersion, buildToolsVersion in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
-    buildToolsVersion "26.0.3"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
 
     defaultConfig {

--- a/ios/RNAdvancedClipboard.m
+++ b/ios/RNAdvancedClipboard.m
@@ -25,6 +25,11 @@ RCT_EXPORT_MODULE()
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(setString:(NSString *)content)
 {
     UIPasteboard *clipboard = [UIPasteboard generalPasteboard];


### PR DESCRIPTION
```
> Task :react-native-advanced-clipboard:verifyReleaseResources FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-advanced-clipboard:verifyReleaseResources'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.Workers$ActionFacade
   > 1 exception was raised by workers:
     com.android.builder.internal.aapt.v2.Aapt2Exception: Android resource linking failed
     /Users/junhoyeo/.gradle/caches/transforms-2/files-2.1/ac578dd963fa0e8b00d9521c2822ad2e/appcompat-1.0.2/res/values-v28/values-v28.xml:5:5-8:13: AAPT: error: resource android:attr/dialogCornerRadius not found.
```

In the recent version of react-native, `./gradlew assembleRelease` fails like the error above.
We can update the `compileSdkVersion`, `buildToolsVersion` in `android/build.gradle` and resolve this issue, with `BUILD SUCCESSFUL` 👍